### PR TITLE
Allow text/xml invoices in intercept filter

### DIFF
--- a/src/intercept-filter.ts
+++ b/src/intercept-filter.ts
@@ -2,6 +2,7 @@ const ALLOWED_MIME_TYPES = new Set([
   "application/xml",
   "application/pkcs7-mime",
   "application/octet-stream", // Odoo bug: recent incoming invoices from other Odoo instances use this.
+  "text/xml", // Manual invoice uploads can be served as text/xml instead of application/xml.
 ]);
 
 export function isAllowedMime(mime: string): boolean {

--- a/tests/unit/intercept-filter.test.ts
+++ b/tests/unit/intercept-filter.test.ts
@@ -17,13 +17,13 @@ describe("intercept filter", () => {
     expect(isAllowedMime("application/xml")).toBe(true);
     expect(isAllowedMime("application/pkcs7-mime")).toBe(true);
     expect(isAllowedMime("application/octet-stream")).toBe(true);
+    expect(isAllowedMime("text/xml")).toBe(true);
   });
 
   it("rejects unrelated mime types", () => {
     expect(isAllowedMime("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).toBe(
       false,
     );
-    expect(isAllowedMime("text/xml")).toBe(false);
     expect(isAllowedMime("")).toBe(false);
   });
 


### PR DESCRIPTION
### Motivation
- Some manually uploaded FatturaPA XML files are served with the `text/xml` MIME type and were being ignored by the intercept filter, preventing previews.

### Description
- Add `"text/xml"` to the `ALLOWED_MIME_TYPES` set in `src/intercept-filter.ts` and document the reason with an inline comment. 
- Update `tests/unit/intercept-filter.test.ts` to assert `isAllowedMime("text/xml")` is allowed. 
- The change touches the intercepted download filtering flow and keeps existing behavior for `application/xml`, `application/pkcs7-mime`, and `application/octet-stream`.

### Testing
- Ran unit tests with `npm run test:unit` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cbf9f1c3883308f873a3717a2183e)