### PR TITLE
Add release PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           files: ${{ steps.package.outputs.zip_name }}
           generate_release_notes: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
if you intend to run workflows on the release event (on: { release: { types: [published] } }), you need to use a personal access token for this action, as the default secrets.GITHUB_TOKEN does not trigger another workflow.